### PR TITLE
Refactor variable name for clarity

### DIFF
--- a/Devantler.K9sCLI.Tests/K9sTests/RunAsyncTests.cs
+++ b/Devantler.K9sCLI.Tests/K9sTests/RunAsyncTests.cs
@@ -14,10 +14,10 @@ public class RunAsyncTests
   public async Task RunAsync_Version_ReturnsVersion()
   {
     // Arrange
-    var (exitCode, message) = await K9s.RunAsync(["version", "-s"]);
+    var (exitCode, output) = await K9s.RunAsync(["version", "-s"]);
 
     // Assert
     Assert.Equal(0, exitCode);
-    Assert.Matches(@"Version\s+v\d+\.\d+\.\d+", message.Split(Environment.NewLine).First().Trim());
+    Assert.Matches(@"Version\s+v\d+\.\d+\.\d+", output.Split(Environment.NewLine).First().Trim());
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ You can execute the K9s CLI commands using the `K9s` class.
 ```csharp
 using Devantler.K9sCLI;
 
-var (exitCode, message) = await K9s.RunAsync(["arg1", "arg2"]);
+var (exitCode, output) = await K9s.RunAsync(["arg1", "arg2"]);
 ```


### PR DESCRIPTION
Update the variable name from 'message' to 'output' in the RunAsync method for improved clarity in the code.