### PR TITLE
Remove deprecated RunAsync method from K9s class

### DIFF
--- a/Devantler.K9sCLI/K9s.cs
+++ b/Devantler.K9sCLI/K9s.cs
@@ -61,41 +61,4 @@ public static class K9s
       includeStdErr: includeStdErr,
       cancellationToken: cancellationToken).ConfigureAwait(false);
   }
-
-  /// <summary>
-  /// Run the K9s CLI.
-  /// </summary>
-  /// <param name="editor"></param>
-  /// <param name="kubeconfig"></param>
-  /// <param name="context"></param>
-  /// <param name="cancellationToken"></param>
-  /// <returns></returns>
-  [Obsolete("This method is deprecated. Use the RunAsync method instead.")]
-  public static async Task RunAsync(Editor editor = Editor.Nano, string? kubeconfig = default, string? context = default, CancellationToken cancellationToken = default)
-  {
-    kubeconfig ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".kube", "config");
-    var command = string.IsNullOrEmpty(context) ?
-      Command.WithArguments(
-        ["--kubeconfig", kubeconfig]
-      ).WithEnvironmentVariables(new Dictionary<string, string?>
-      {
-        ["EDITOR"] = editor.ToString().ToLower(CultureInfo.CurrentCulture),
-        ["KUBE_EDITOR"] = editor.ToString().ToLower(CultureInfo.CurrentCulture)
-      }) :
-      Command.WithArguments(
-        ["--kubeconfig", kubeconfig, "--context", context]
-      ).WithEnvironmentVariables(new Dictionary<string, string?>
-      {
-        ["EDITOR"] = editor.ToString().ToLower(CultureInfo.CurrentCulture),
-        ["KUBE_EDITOR"] = editor.ToString().ToLower(CultureInfo.CurrentCulture)
-      });
-    try
-    {
-      _ = await CLI.RunAsync(command, cancellationToken: cancellationToken).ConfigureAwait(false);
-    }
-    catch (CommandExecutionException ex)
-    {
-      throw new K9sException(ex.Message);
-    }
-  }
 }

--- a/Devantler.K9sCLI/K9s.cs
+++ b/Devantler.K9sCLI/K9s.cs
@@ -1,7 +1,5 @@
-﻿using System.Globalization;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using CliWrap;
-using CliWrap.Exceptions;
 using Devantler.CLIRunner;
 
 namespace Devantler.K9sCLI;


### PR DESCRIPTION
Eliminate the deprecated RunAsync method to streamline the K9s class and encourage the use of updated methods.