### PR TITLE
Update EnumMember values for Nano and Vim to full paths

### DIFF
--- a/Devantler.K9sCLI/Editor.cs
+++ b/Devantler.K9sCLI/Editor.cs
@@ -10,11 +10,12 @@ public enum Editor
   /// <summary>
   /// Nano
   /// </summary>
-  [EnumMember(Value = "nano")]
+  [EnumMember(Value = "/usr/bin/nano")]
   Nano,
+
   /// <summary>
   /// Vim
   /// </summary>
-  [EnumMember(Value = "vim")]
+  [EnumMember(Value = "/usr/bin/vim")]
   Vim
 }


### PR DESCRIPTION
Change EnumMember values for Nano and Vim to include their full paths for better clarity and consistency.