### PR TITLE
Remove EnumMember attributes for Nano and Vim in Editor enum

### DIFF
--- a/Devantler.K9sCLI/Editor.cs
+++ b/Devantler.K9sCLI/Editor.cs
@@ -1,5 +1,3 @@
-using System.Runtime.Serialization;
-
 namespace Devantler.K9sCLI;
 
 /// <summary>
@@ -10,12 +8,10 @@ public enum Editor
   /// <summary>
   /// Nano
   /// </summary>
-  [EnumMember(Value = "/usr/bin/nano")]
   Nano,
 
   /// <summary>
   /// Vim
   /// </summary>
-  [EnumMember(Value = "/usr/bin/vim")]
   Vim
 }


### PR DESCRIPTION
Eliminate unnecessary EnumMember attributes for the Nano and Vim editors in the Editor enum.